### PR TITLE
possible IndexError for `q_table`

### DIFF
--- a/modelfree/q_learning_mountaincar.py
+++ b/modelfree/q_learning_mountaincar.py
@@ -48,6 +48,8 @@ def obs_to_state(env, obs):
     env_dx = (env_high - env_low) / n_states
     a = int((obs[0] - env_low[0])/env_dx[0])
     b = int((obs[1] - env_low[1])/env_dx[1])
+    a = a if a < n_states else n_states - 1
+    b = b if b < n_states else n_states - 1
     return a, b
 
 if __name__ == '__main__':


### PR DESCRIPTION
if `obs[1]` equals to `env_high[1]` or `obs[0]` equals to `env_high[0]`, it would throw an index error, since the shape of `q_table` is `n_states x n_states x 3`.